### PR TITLE
URLs in package.json are wrong

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/badunk/fixtures"
+    "url": "https://github.com/badunk/js-fixtures"
   },
   "bugs": {
-    "url": "https://github.com/badunk/fixtures/issues"
+    "url": "https://github.com/badunk/js-fixtures/issues"
   },
   "main": "./fixtures",
   "engines": {


### PR DESCRIPTION
Hi!

While trying to find a JS lib for fixtures, I stumbled about js-fixtures and noticed that the URLs you use for your project in your package.json aren't correct, see: https://npmjs.org/package/js-fixtures
This commit should fix that. :)

It was:
https://github.com/badunk/fixtures

It should be:
https://github.com/badunk/js-fixtures
