### PR TITLE
Script errors in fixtures are not reported in the parent window.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,6 @@ Finally, there are two convenience methods to access the contents of the sandbox
 Options:
 - `fixtures.containerId`
   - change the ID of the iframe that gets injected into the page
-- `fixtures.visible`
-  - make fixtures 'visible' in the DOM (default: false)
 - `fixtures.path`
  - change the path to look for fixtures (default: `spec/javascripts/fixtures`)
 

--- a/fixtures.js
+++ b/fixtures.js
@@ -18,7 +18,6 @@
 
         self.containerId = 'js-fixtures';
         self.path = 'spec/javascripts/fixtures';
-        self.visible = false;
         self.window = function(){
             var iframe = document.getElementById(self.containerId);
             if (!iframe) return null;
@@ -64,15 +63,8 @@
             var cb = typeof arguments[arguments.length - 1] === 'function' ? arguments[arguments.length -1] : null;
             var iframe = document.createElement('iframe');
             iframe.setAttribute('id', self.containerId);
-            if (self.visible) {
-                // Firefox needs the frame to be displayed in order for the contents
-                // to register as 'visible'.
-                iframe.style.display = 'block';
-                iframe.style.width = '1px';
-                iframe.style.height = '1px';
-            } else {
-                iframe.style.display = 'none';
-            }
+            iframe.style.opacity = 0;
+            iframe.style.filter = 'alpha(0)';
 
             document.body.appendChild(iframe);
             var doc = iframe.contentWindow || iframe.contentDocument;

--- a/fixtures.js
+++ b/fixtures.js
@@ -80,6 +80,7 @@
             }
 
             doc.open();
+            doc.defaultView.onerror = captureErrors;
             doc.write(html)
             doc.close();
         };
@@ -87,6 +88,15 @@
             var container = document.getElementById(self.containerId);
             if (!container) createContainer.apply(self, arguments);
             else self.window().document.body.innerHTML += html;
+        };
+        var captureErrors = function(){
+            if (window.onerror){
+                // Rewrite the message prefix to indicate that the error
+                // occurred in the fixture.
+                arguments[0] = arguments[0].replace(/^[^:]*/, "Uncaught fixture error");
+                window.onerror.apply(window, arguments);
+            }
+            return true;
         };
         var getFixtureHtml = function(url){
             if (typeof fixturesCache[url] === 'undefined'){

--- a/test/fixtures-spec.js
+++ b/test/fixtures-spec.js
@@ -50,6 +50,29 @@ define(function(require){
                     expect(button.offsetHeight).to.be.greaterThan(0);
                     expect(button.offsetWidth).to.be.greaterThan(0);
                 });
+                describe("throws an unhandled error", function(){
+                    var errorHandler;
+                    beforeEach(function(){
+                        errorHandler = window.onerror;
+                    });
+                    afterEach(function(){
+                        window.onerror = errorHandler;
+                    });
+                    it("is reported in the parent window", function(done){
+                        window.onerror = function (message) {
+                            // Need to manually pass failed exceptions to the
+                            // callback since we have overriden the default
+                            // error handler for the test case.
+                            try {
+                                expect(message).to.equal('Uncaught fixture error: boom');
+                                return done();
+                            } catch (error) {
+                                return done(error);
+                            }
+                        };
+                        fixtures.set('<scr' + 'ipt>throw new Error("boom")</scr' + 'ipt>');
+                    });
+                });
             });
             describe("body", function(){
                 it("should not be null when initialized properly", function(){

--- a/test/fixtures-spec.js
+++ b/test/fixtures-spec.js
@@ -33,9 +33,6 @@ define(function(require){
                 it("should set 'spec/javascripts/fixtures/' as the default fixtures path", function(){
                     expect(fixtures.path).to.equal('spec/javascripts/fixtures');
                 });
-                it("should disable fixture visibility by default", function(){
-                    expect(fixtures.visible).to.equal(false);
-                });
                 it("should set body to null", function(){
                     expect(fixtures.body()).to.be(null);
                 });
@@ -43,45 +40,15 @@ define(function(require){
                     expect(fixtures.window()).to.be(null);
                 });
             });
-            describe("visible", function(){
+            describe("content", function(){
                 // jQuery defines 'visible' based on if an element consumes space in the page layout.
                 // See http://api.jquery.com/visible-selector/
                 // and https://github.com/jquery/jquery/blob/master/src/css/hiddenVisibleSelectors.js
-                var oldVisible;
-                beforeEach(function(){
-                    oldVisible = fixtures.visible;
-                });
-                afterEach(function(){
-                    fixtures.visible = oldVisible;
-                });
-                
-                describe("when enabled", function(){
-                    beforeEach(function(){
-                        fixtures.visible = true;
-                        fixtures.set("<button id='test'>Test</button>");
-                    });
-                    it("should display fixtures", function(){
-                        var container = document.getElementById(fixtures.containerId);
-                        var button = fixtures.window().document.getElementById('test');
-                        expect(container.style.display).to.equal('block');
-                        // Firefox will collapse inner dimensions to 0 if the
-                        // element is not displayed.
-                        expect(button.offsetHeight).to.be.greaterThan(0);
-                        expect(button.offsetWidth).to.be.greaterThan(0);
-                    });
-                });
-                describe("when disabled", function(){
-                    beforeEach(function(){
-                        fixtures.visible = false;
-                        fixtures.set("<button id='test'>Test</button>");
-                    });
-                    it("should hide fixtures", function(){
-                        var container = document.getElementById(fixtures.containerId);
-                        var button = fixtures.window().document.getElementById('test');
-                        expect(container.style.display).to.equal('none');
-                        // Chrome never collapses the element while Firefox
-                        // does so we don't test dimensions here.
-                    });
+                it("should be 'visible'", function(){
+                    fixtures.set("<button id='test'>Test</button>");
+                    var button = fixtures.window().document.getElementById('test');
+                    expect(button.offsetHeight).to.be.greaterThan(0);
+                    expect(button.offsetWidth).to.be.greaterThan(0);
                 });
             });
             describe("body", function(){


### PR DESCRIPTION
When using karma+mocha+js-fixtures to do UI testing, I noticed that tests that depend on the results of UI events in a fixture do not report the failures -- they just timeout. The problem seems to be that assertions that execute in an event handler belonging to the fixture document are caught by the fixture window's `onerror` handler and not reported to the parent (where mocha is listening for uncaught errors). For example, assuming jQuery is present, the following UI code would cause the following test to report a timeout rather than an assertion failure:

UI code:

```
<button id='toggle'>Toggle</button>
<div id='target' style='display:none'>Target</div>
<script>
$('#toggle').click(function(){
    // Adding this comment to demonstrate the intent of the test while maintaining
    // the failure condition.
    // $('#target').toggle();
});
</script>
```

Test code:

```
it("displays the div if the button is clicked", function(done){
    var $ = fixtures.window().$;
    var button = $('#toggle');

    button.one('click', function(){
        var div = $('#target');
        expect(div.is(':visible')).to.be(true);
        done();
    });

    button.click();
});
```

This code builds upon the code for #19.
