### PR TITLE
New method: fixtures.bodyAsDom()

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,11 @@ Additionally, two clean up methods are provided:
 - `cleanUp()`
   - cleans-up fixtures container
 
-Finally, there are two convenience methods to access the contents of the sandboxed iframe:
+Finally, there are three convenience methods to access the contents of the sandboxed iframe:
 - `body`
   - returns the html contents of the body.  Use it to assert various values on the body of the iframe DOM.
+- `bodyAsDom`
+  - return the html contents of the body's children. Use it if you want to traverse through the DOM.
 - `window`
   - returns the global window reference of the iframe, giving you the ability to use the global variables injected into that context.
   

--- a/fixtures.js
+++ b/fixtures.js
@@ -30,6 +30,12 @@
             var content = self.window().document.body.innerHTML;
             return content; 
         };
+        self.bodyAsDom = function(){
+            var content = self.body();
+            var parser = new DOMParser();
+            var domContent = parser.parseFromString(content, 'text/html');
+            return domContent.body.children;
+        };
         self.load = function(html){
             var cb = typeof arguments[arguments.length - 1] === 'function' ? arguments[arguments.length -1] : null;
             addToContainer(self.read.apply(self, arguments), cb);

--- a/test/fixtures-spec.js
+++ b/test/fixtures-spec.js
@@ -36,6 +36,9 @@ define(function(require){
                 it("should set body to null", function(){
                     expect(fixtures.body()).to.be(null);
                 });
+                it("should set bodyAsDom to 'empty' object", function(){
+                    expect(fixtures.bodyAsDom()).to.eql({length: 0});
+                });
                 it("should set window to null", function(){
                     expect(fixtures.window()).to.be(null);
                 });
@@ -83,6 +86,19 @@ define(function(require){
                     var sillyString = 'some silly string';
                     fixtures.set(sillyString);
                     expect(fixtures.body()).to.equal(sillyString);
+                });
+            });
+            describe("bodyAsDom", function(){
+                it("should not be null when initialized properly", function(){
+                    fixtures.set('test');
+                    expect(fixtures.bodyAsDom()).to.not.be(null);
+                });
+                it("should return the body contents of the iframe as DOM", function() {
+                    var sillyNode = '<span>some silly node</span>';
+                    var parser = new DOMParser();
+                    var parsedString = parser.parseFromString(sillyNode, "text/html");
+                    fixtures.set(sillyNode);
+                    expect(fixtures.bodyAsDom()).to.eql({0: parsedString, length: 1});
                 });
             });
             describe("window", function(){


### PR DESCRIPTION
The only caveat I can see so far is after parsing the string as DOM, that _sometimes_ the browser complains about not being able to read cookie property of document. In some cases, running a server with enabled CORS did the trick (as in `http-server -p 8000 --cors` for npm's http-server package).

Could you assist me here?
