### PR TITLE
Expose functions to control the opaqueness of the fixture frame

### DIFF
--- a/fixtures.js
+++ b/fixtures.js
@@ -60,6 +60,12 @@
 
             iframe.parentNode.removeChild(iframe);
         };
+        self.show = function() {
+            document.getElementById(self.containerId).style.opacity = 1;
+        };
+        self.hide = function() {
+            document.getElementById(self.containerId).style.opacity = 0;
+        };
         var createContainer  = function(html){
             var cb = typeof arguments[arguments.length - 1] === 'function' ? arguments[arguments.length -1] : null;
             var iframe = document.createElement('iframe');


### PR DESCRIPTION
I don't know why the iframe is by default fully opaque, but this PR makes the opaqueness controllable by the user.
